### PR TITLE
ADD:SignUp구현

### DIFF
--- a/src/SignIn/SignIn.jsx
+++ b/src/SignIn/SignIn.jsx
@@ -1,8 +1,77 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from './SignIn.style';
 
 const SignIn = () => {
-  return <div></div>;
+  const navigate = useNavigate();
+
+  const [input, setInput] = useState({ email: '', pw: '' });
+
+  const saveInput = e => {
+    setInput(prevInput => ({ ...prevInput, [e.target.name]: e.target.value }));
+  };
+  const goSignIn = () => {
+    fetch('https://www.pre-onboarding-selection-task.shop/auth/signin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json;charset=utf-8' },
+      body: JSON.stringify({
+        email: input.email,
+        password: input.pw,
+      }),
+    })
+      .then(response => {
+        return response.json();
+      })
+      .then(data => {
+        localStorage.setItem('token', data.access_token);
+        if (localStorage.getItem('token') !== 'undefined') {
+          return navigate('/todo');
+        } else {
+          alert('아이디 혹은 비밀번호가 일치하지 않습니다.');
+        }
+      });
+  };
+
+  useEffect(() => {
+    if (localStorage.getItem('token')) {
+      navigate('/todo');
+    }
+  }, []);
+
+  return (
+    <S.SigninContainer>
+      <S.SigninTitle>Sign-in</S.SigninTitle>
+      <S.IdAndPwInput
+        name="email"
+        data-testid="email-input"
+        type="text"
+        placeholder="이메일을 입력해 주세요"
+        onChange={saveInput}
+        value={input.email}
+      />
+      <S.IdAndPwInput
+        name="pw"
+        data-testid="password-input"
+        type="password"
+        placeholder="패스워드를 입력해 주세요"
+        onChange={saveInput}
+        value={input.pw}
+      />
+      {input.email.includes('@') && input.pw.length >= 8 ? (
+        <S.SignInBtn
+          data-testid="signin-button"
+          disabled={false}
+          onClick={goSignIn}
+        >
+          로그인
+        </S.SignInBtn>
+      ) : (
+        <S.SignInBtn data-testid="signin-button" disabled={true}>
+          로그인
+        </S.SignInBtn>
+      )}
+    </S.SigninContainer>
+  );
 };
 
 export default SignIn;

--- a/src/SignIn/SignIn.style.js
+++ b/src/SignIn/SignIn.style.js
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+export const SigninContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  flex-wrap: wrap;
+  width: 350px;
+  height: 402px;
+  margin: 200px auto;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  background-color: #fff;
+`;
+
+export const SigninTitle = styled.p`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  margin: 36px 0;
+  font-size: 48px;
+  font-weight: 700;
+`;
+
+export const IdAndPwInput = styled.input`
+  display: block;
+  width: 268px;
+  height: 40px;
+  margin-bottom: 10px;
+  padding: 2px;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  line-height: 30px;
+
+  ::placeholder {
+    padding-left: 10px;
+  }
+
+  :focus {
+    border-color: #dbd;
+  }
+`;
+
+export const SignInBtn = styled.button`
+  width: 268px;
+  height: 40px;
+  margin-top: 20px;
+  border-radius: 8px;
+  border: 1px solid #dbdbdb;
+  font-weight: 500;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- signup 페이지 레이아웃 및 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
로그인 페이지에서 버튼을 클릭 시, 로그인을 진행하고 로그인이 정상적으로 완료되었을 시 /todo 경로로 이동
input에 value로 input.email과 input.pw 를 주어 해당 이메일과 비밀번호로 로그인 할 수 있도록 구현 
로그인 버튼은 disabled로 설정하였으며,  이메일 : @ 포함 및 비밀번호 8자리 이상 조건을 달성해야 버튼이 활성화되도록 구현 

<br />

## :: 기타 질문 및 특이 사항
없음