### PR TITLE
ADD:signup구현

### DIFF
--- a/src/SignUp/SignUp.jsx
+++ b/src/SignUp/SignUp.jsx
@@ -1,8 +1,68 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from './SignUp.style';
 
 const SignUp = () => {
-  return <div></div>;
+  const navigate = useNavigate();
+  const goSignUp = () => {
+    fetch('https://www.pre-onboarding-selection-task.shop/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: input.email,
+        password: input.pw,
+      }),
+    }).then(response => {
+      if (response.status === 201) {
+        console.log(response);
+        navigate('/signin');
+      } else {
+        alert('이미 가입된 이메일 입니다');
+      }
+    });
+  };
+  useEffect(() => {
+    if (localStorage.getItem('token')) {
+      navigate('/todo');
+    }
+  }, []);
+  const [input, setInput] = useState({ email: '', pw: '' });
+  const saveInput = e => {
+    setInput(prevInput => ({ ...prevInput, [e.target.name]: e.target.value }));
+  };
+  return (
+    <S.SignupContainer>
+      <S.SignUpTitle>Sign-up</S.SignUpTitle>
+      <S.IdAndPwInput
+        name="email"
+        data-testid="email-input"
+        type="text"
+        placeholder="@을 포함한 이메일을 입력해 주세요"
+        onChange={saveInput}
+        value={input.email}
+      />
+      <S.IdAndPwInput
+        name="pw"
+        data-testid="password-input"
+        type="password"
+        placeholder="패스워드 8자리 이상을 입력해 주세요"
+        onChange={saveInput}
+        value={input.pw}
+      />
+      {input.email.includes('@') && input.pw.length >= 8 ? (
+        <S.SignUpBtn
+          data-testid="signup-button"
+          disabled={false}
+          onClick={goSignUp}
+        >
+          회원가입
+        </S.SignUpBtn>
+      ) : (
+        <S.SignUpBtn data-testid="signup-button" disabled={true}>
+          회원가입
+        </S.SignUpBtn>
+      )}
+    </S.SignupContainer>
+  );
 };
-
 export default SignUp;

--- a/src/SignUp/SignUp.style.js
+++ b/src/SignUp/SignUp.style.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+export const SignupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  flex-wrap: wrap;
+  width: 350px;
+  height: 402px;
+  margin: 200px auto;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  background-color: #fff;
+`;
+export const SignUpTitle = styled.p`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  margin: 36px 0;
+  font-size: 48px;
+  font-weight: 700;
+`;
+export const IdAndPwInput = styled.input`
+  display: block;
+  width: 268px;
+  height: 40px;
+  margin-bottom: 10px;
+  padding: 2px;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  line-height: 30px;
+  ::placeholder {
+    padding-left: 10px;
+  }
+  :focus {
+    border-color: #dbd;
+  }
+`;
+export const SignUpBtn = styled.button`
+  width: 268px;
+  height: 40px;
+  margin-top: 20px;
+  border-radius: 8px;
+  border: 1px solid #dbdbdb;
+  font-weight: 500;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
signup 페이지 레이아웃 및 기능구현
-

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

회원가입 이메일과 비밀번호의 유효성 검사기능을 구현
이메일 조건: @ 포함
비밀번호 조건: 8자 이상

- 입력된 이메일과 비밀번호가 유효성 검사를 통과하지 못한다면 button에 disabled 속성 부여
- 버튼을 클릭 시 회원가입을 진행하고 회원가입이 정상적으로 완료되었을 시 /signin 경로로 이동
- 로그인 API는 로그인이 성공했을 시 Response Body에 JWT를 포함해서 응답하며, JWT 로컬 스토리지에 저장하기
- 로컬 스토리지에 토큰이 있는 상태로 /signin 또는 /signup 페이지에 접속한다면 /todo 경로로 리다이렉트 시키기

<br />

## :: 기타 질문 및 특이 사항
없습니다.